### PR TITLE
Fix auth url

### DIFF
--- a/cmd/rmtool/main.go
+++ b/cmd/rmtool/main.go
@@ -193,6 +193,8 @@ func readToken(s settings) (string, error) {
 }
 
 func saveToken(s settings, token string) {
+	// ignoring error b/c we have error handling for the case of unable to write the token
+	_ = os.MkdirAll(s.dataDir, 0755)
 	tokenfile := filepath.Join(s.dataDir, "device-token")
 	f, err := os.Create(tokenfile)
 	if err != nil {

--- a/cmd/rmtool/main.go
+++ b/cmd/rmtool/main.go
@@ -143,10 +143,30 @@ func setupClient(s settings) (*api.Client, error) {
 	return client, nil
 }
 
+func promptUserForRegCode() (string, error) {
+	fmt.Print("Enter one-time code (go to https://my.remarkable.com/device/connect/desktop): ")
+	var code string
+
+	// Taking input from user
+	_, err := fmt.Scanln(&code)
+	if err != nil {
+		return "", err
+	}
+
+	if len(code) != 8 {
+		fmt.Printf("Code has the wrong length, it should be 8, but got %d '%s'\n", len(code), code)
+		return promptUserForRegCode()
+	}
+
+	return code, nil
+}
+
 func register(s settings, client *api.Client) error {
-	fmt.Printf("Register rmtool with remarkable\n")
-	// TODO: prompt user
-	code := ""
+
+	code, err := promptUserForRegCode()
+	if err != nil {
+		return err
+	}
 	token, err := client.Register(code)
 	if err != nil {
 		return err

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -539,6 +539,10 @@ func (c *Client) Register(code string) (string, error) {
 		return "", err
 	}
 
+	_, err = parseTokenExpiration(token)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse provided token - %w", err)
+	}
 	c.deviceToken = token
 	c.userToken = ""
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,7 +20,8 @@ import (
 
 // Default URLs
 const (
-	AuthURL                   = "https://my.remarkable.com"
+	//
+	AuthURL                   = "https://webapp-production-dot-remarkable-production.appspot.com"
 	StorageDiscoveryURL       = "https://service-manager-production-dot-remarkable-production.appspot.com/service/json/1/document-storage?environment=production&group=auth0%7C5a68dc51cb30df3877a1d7c4&apiVer=2"
 	NotificationsDiscoveryURL = "https://service-manager-production-dot-remarkable-production.appspot.com/service/json/1/notifications?environment=production&group=auth0%7C5a68dc51cb30df3877a1d7c4&apiVer=1"
 )

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -20,6 +20,7 @@ import (
 	"github.com/akeil/rmtool/internal/logging"
 )
 
+// Implements the Repository interface
 type repo struct {
 	client  *Client
 	dataDir string

--- a/pkg/fs/fsrepo.go
+++ b/pkg/fs/fsrepo.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/akeil/rmtool"
-	fsx "github.com/akeil/rmtool/internal/errors"
+	"github.com/akeil/rmtool/internal/errors"
 	fsx "github.com/akeil/rmtool/internal/fs"
 	"github.com/akeil/rmtool/internal/logging"
 )
 
+// Implements the Repository interface
 type repo struct {
 	base string
 }


### PR DESCRIPTION
It seems remarkable has changed their auth API
https://github.com/juruen/rmapi/issues/177
https://github.com/juruen/rmapi/commit/bb7611d9732012181af2a187433fc62aa46be411

I also added some code to make sure we get a valid token when registering using the parseTokenExpiration function